### PR TITLE
Remove this.props.extraHeight from calculation

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -69,7 +69,7 @@ const KeyboardAwareMixin = {
           if (isAncestor) {
             // Check if the TextInput will be hidden by the keyboard
             UIManager.measureInWindow(currentlyFocusedField, (x, y, width, height) => {
-              if (y + height > frames.endCoordinates.screenY - this.props.extraScrollHeight - this.props.extraHeight) {
+              if (y + height > frames.endCoordinates.screenY - this.props.extraScrollHeight) {
                 this.scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
               }
             })


### PR DESCRIPTION
With extraHeight in the calculation, the page can scroll negatively. Removing it still allows everything to scroll correctly, but prevents the page from scrolling down