### PR TITLE
Reset scroll fix

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -85,7 +85,7 @@ const KeyboardAwareMixin = {
   },
 
   resetKeyboardSpace: function () {
-    const keyboardSpace: number = (this.props.viewIsInsideTabBar) ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight : this.props.extraScrollHeight
+    const keyboardSpace: number = (this.props.viewIsInsideTabBar) ? _KAM_DEFAULT_TAB_BAR_HEIGHT : 0
     this.setState({keyboardSpace})
     // Reset scroll position after keyboard dismissal
     if (this.props.enableResetScrollToCoords === false) {


### PR DESCRIPTION
removing extraScrollHeight from the reset scroll position to prevent extra space being at the bottom of the screen after resetting the scroll.